### PR TITLE
increased file limit for json files to 50mb

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,13 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { urlencoded, json } from 'express';
 
 async function bootstrap() {
 	const app = await NestFactory.create(AppModule);
+
+	app.use(json({ limit: '50mb' }));
+	app.use(urlencoded({ extended: true, limit: '50mb' }));
+	app.enableCors();
 	await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
increased file limit for json files to 50mb.
This was neccesary for the OPC UA-mapping, since OPC UA models are normaly larger than the default value, resulting in Error 413 payload too large.